### PR TITLE
Add support for IndieAuth Metadata endpoint

### DIFF
--- a/v2/endpoints.go
+++ b/v2/endpoints.go
@@ -1,6 +1,8 @@
 package indieauth
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"mime"
 	"net/http"
 	"net/url"
@@ -52,6 +54,17 @@ func (c *Config) FindEndpoints(me string) (Endpoints, error) {
 		}
 	}
 
+	metadataEndpoints := links.FilterByRel("indieauth-metadata")
+	if len(metadataEndpoints) != 0 {
+		metadataEndpoint := metadataEndpoints[0]
+		linkURL, err := meURL.Parse(metadataEndpoint.URL)
+		if err != nil {
+			return endpoints, err
+		}
+		err = c.findByDiscoveryEndpoint(client, linkURL, &endpoints)
+		return endpoints, err
+	}
+
 	for _, link := range links {
 		if link.Rel == "authorization_endpoint" && endpoints.Authorization == nil {
 			linkURL, err := meURL.Parse(link.URL)
@@ -79,4 +92,37 @@ func (c *Config) FindEndpoints(me string) (Endpoints, error) {
 	}
 
 	return endpoints, nil
+}
+
+func (c *Config) findByDiscoveryEndpoint(client *http.Client, url *url.URL, endpoints *Endpoints) error {
+	resp, err := client.Get(url.String())
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 200 {
+		return &RequestError{
+			StatusCode: resp.StatusCode,
+		}
+	}
+
+	var body map[string]string
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	json.Unmarshal(bodyBytes, &body)
+	linkURL, err := url.Parse(body["authorization_endpoint"])
+	if err == nil {
+		endpoints.Authorization = linkURL
+	}
+	linkURL, err = url.Parse(body["token_endpoint"])
+	if err == nil {
+		endpoints.Token = linkURL
+	}
+
+	return nil
 }


### PR DESCRIPTION
As part of a recent update to the IndieAuth spec, we've introduced the
`indieauth-metadata` endpoint, which allows us to push more
configuration for our service into a specific endpoint for
configuration, similar to RFC8414.

We should support this discovery for those who support it, falling back
to the legacy HTML/Link-only means when not supported.

Closes #1.

---

Not done a tonne of Go, so happy to tweak this so it matches what's a better practice!